### PR TITLE
Introduce frame lookup helper

### DIFF
--- a/Core/GUI/GUI_Utility.lua
+++ b/Core/GUI/GUI_Utility.lua
@@ -162,20 +162,7 @@ function MilaUI:UpdateFramePosition(unitName)
         return
     end
     
-    local frameObj = nil
-    if unitName == "Player" then
-        frameObj = self.PlayerFrame
-    elseif unitName == "Target" then
-        frameObj = self.TargetFrame
-    elseif unitName == "Focus" then
-        frameObj = self.FocusFrame
-    elseif unitName == "Pet" then
-        frameObj = self.PetFrame
-    elseif unitName == "TargetTarget" then
-        frameObj = self.TargetTargetFrame
-    elseif unitName == "FocusTarget" then
-        frameObj = self.FocusTargetFrame
-    end
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
     
     if frameObj then
         local Frame = MilaUI.DB.profile.Unitframes[unitName].Frame
@@ -191,20 +178,7 @@ function MilaUI:UpdateHealthBarSize(unitName)
         return
     end
     
-    local frameObj = nil
-    if unitName == "Player" then
-        frameObj = self.PlayerFrame
-    elseif unitName == "Target" then
-        frameObj = self.TargetFrame
-    elseif unitName == "Focus" then
-        frameObj = self.FocusFrame
-    elseif unitName == "Pet" then
-        frameObj = self.PetFrame
-    elseif unitName == "TargetTarget" then
-        frameObj = self.TargetTargetFrame
-    elseif unitName == "FocusTarget" then
-        frameObj = self.FocusTargetFrame
-    end
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
     
     if frameObj and frameObj.unitHealthBar then
         local Health = MilaUI.DB.profile.Unitframes[unitName].Health
@@ -217,17 +191,7 @@ function MilaUI:UpdateCastbarSize(unitName)
         return
     end
 
-    -- Map unit names to frame objects
-    local frameMap = {
-        Player = self.PlayerFrame,
-        Target = self.TargetFrame,
-        Focus = self.FocusFrame,
-        Pet = self.PetFrame,
-        TargetTarget = self.TargetTargetFrame,
-        FocusTarget = self.FocusTargetFrame,
-    }
-
-    local frameObj = frameMap[unitName]
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
     if frameObj and frameObj.Castbar then
         local castbarSettings = MilaUI.DB.profile.Unitframes[unitName].Castbar
         if castbarSettings.width and castbarSettings.height then
@@ -246,20 +210,7 @@ function MilaUI:UpdateCastbarPosition(unitName)
         return
     end
     
-    local frameObj = nil
-    if unitName == "Player" then
-        frameObj = self.PlayerFrame
-    elseif unitName == "Target" then
-        frameObj = self.TargetFrame
-    elseif unitName == "Focus" then
-        frameObj = self.FocusFrame
-    elseif unitName == "Pet" then
-        frameObj = self.PetFrame
-    elseif unitName == "TargetTarget" then
-        frameObj = self.TargetTargetFrame
-    elseif unitName == "FocusTarget" then
-        frameObj = self.FocusTargetFrame
-    end
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
     
     print("frameObj found: " .. (frameObj and "yes" or "no"))
     print("frameObj.Castbar exists: " .. (frameObj and frameObj.Castbar and "yes" or "no"))
@@ -337,20 +288,7 @@ function MilaUI:UpdateCastbarAppearance(unitName)
         return
     end
     
-    local frameObj = nil
-    if unitName == "Player" then
-        frameObj = self.PlayerFrame
-    elseif unitName == "Target" then
-        frameObj = self.TargetFrame
-    elseif unitName == "Focus" then
-        frameObj = self.FocusFrame
-    elseif unitName == "Pet" then
-        frameObj = self.PetFrame
-    elseif unitName == "TargetTarget" then
-        frameObj = self.TargetTargetFrame
-    elseif unitName == "FocusTarget" then
-        frameObj = self.FocusTargetFrame
-    end
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
     
     if frameObj and frameObj.Castbar then
         local castbar = frameObj.Castbar
@@ -424,13 +362,9 @@ function MilaUI:UpdateCastbarAppearance(unitName)
 end
 
 function MilaUI:UpdateAllCastbars()
-    self:UpdateCastbarAppearance("Player")
-    self:UpdateCastbarAppearance("Target")
-    self:UpdateCastbarAppearance("Focus")
-    self:UpdateCastbarAppearance("Pet")
-    self:UpdateCastbarAppearance("TargetTarget")
-    self:UpdateCastbarAppearance("FocusTarget")
-    -- Add boss frames if needed
+    for _, unit in ipairs(MilaUI.UnitList) do
+        self:UpdateCastbarAppearance(unit)
+    end
     for i = 1, MAX_BOSS_FRAMES do
         self:UpdateCastbarAppearance("Boss" .. i)
     end

--- a/Core/Modules/Unitframes/Castbar.lua
+++ b/Core/Modules/Unitframes/Castbar.lua
@@ -66,32 +66,9 @@ function MilaUI:ShowTestCastbar(unitName, persistent)
         persistent = true
     end
     
-    local frameObj = nil
-    if unitName == "Player" then
-        frameObj = self.PlayerFrame
-        print("Looking for Player frame: " .. (frameObj and "found" or "not found"))
-    elseif unitName == "Target" then
-        frameObj = self.TargetFrame
-        print("Looking for Target frame: " .. (frameObj and "found" or "not found"))
-    elseif unitName == "Focus" then
-        frameObj = self.FocusFrame
-        print("Looking for Focus frame: " .. (frameObj and "found" or "not found"))
-    elseif unitName == "Pet" then
-        frameObj = self.PetFrame
-        print("Looking for Pet frame: " .. (frameObj and "found" or "not found"))
-    elseif unitName == "TargetTarget" then
-        frameObj = self.TargetTargetFrame
-        print("Looking for TargetTarget frame: " .. (frameObj and "found" or "not found"))
-    elseif unitName == "FocusTarget" then
-        frameObj = self.FocusTargetFrame
-        print("Looking for FocusTarget frame: " .. (frameObj and "found" or "not found"))
-    elseif string.match(unitName, "Boss%d") then
-        local bossIndex = string.match(unitName, "Boss(%d)")
-        print("Looking for Boss frame with index: " .. tostring(bossIndex))
-        if bossIndex and MilaUI.BossFrames and MilaUI.BossFrames[tonumber(bossIndex)] then
-            frameObj = MilaUI.BossFrames[tonumber(bossIndex)]
-            print("Boss frame found: " .. (frameObj and "yes" or "no"))
-        end
+    local frameObj = MilaUI:GetFrameForUnit(unitName)
+    if frameObj then
+        print("Found frame for " .. unitName)
     end
     
     if not frameObj then
@@ -235,7 +212,7 @@ end
 
 -- Function to stop all test castbars
 function MilaUI:StopAllTestCastbars()
-    local unitNames = {"Player", "Target", "Focus", "Pet", "TargetTarget", "FocusTarget"}
+    local unitNames = {unpack(MilaUI.UnitList)}
     
     -- Add boss frames
     for i = 1, MAX_BOSS_FRAMES do
@@ -243,25 +220,7 @@ function MilaUI:StopAllTestCastbars()
     end
     
     for _, unitName in ipairs(unitNames) do
-        local frameObj = nil
-        if unitName == "Player" then
-            frameObj = self.PlayerFrame
-        elseif unitName == "Target" then
-            frameObj = self.TargetFrame
-        elseif unitName == "Focus" then
-            frameObj = self.FocusFrame
-        elseif unitName == "Pet" then
-            frameObj = self.PetFrame
-        elseif unitName == "TargetTarget" then
-            frameObj = self.TargetTargetFrame
-        elseif unitName == "FocusTarget" then
-            frameObj = self.FocusTargetFrame
-        elseif string.match(unitName, "Boss%d") then
-            local bossIndex = string.match(unitName, "Boss(%d)")
-            if bossIndex and MilaUI.BossFrames and MilaUI.BossFrames[tonumber(bossIndex)] then
-                frameObj = MilaUI.BossFrames[tonumber(bossIndex)]
-            end
-        end
+        local frameObj = MilaUI:GetFrameForUnit(unitName)
         
         if frameObj and frameObj.Castbar then
             local castbar = frameObj.Castbar

--- a/Core/Modules/Unitframes/Utility.lua
+++ b/Core/Modules/Unitframes/Utility.lua
@@ -11,6 +11,34 @@ MilaUI.Frames = {
     ["targettarget"] = "TargetTarget",
 }
 
+-- Common unit names used across the addon
+MilaUI.UnitList = {"Player", "Target", "Focus", "Pet", "TargetTarget", "FocusTarget"}
+
+-- Helper to resolve a unit name to its frame object
+function MilaUI:GetFrameForUnit(unitName)
+    if not unitName then return nil end
+
+    local map = {
+        Player = self.PlayerFrame,
+        Target = self.TargetFrame,
+        Focus = self.FocusFrame,
+        Pet = self.PetFrame,
+        TargetTarget = self.TargetTargetFrame,
+        FocusTarget = self.FocusTargetFrame,
+    }
+
+    if map[unitName] then
+        return map[unitName]
+    end
+
+    local bossIndex = unitName:match("^Boss(%d+)$")
+    if bossIndex and MilaUI.BossFrames then
+        return MilaUI.BossFrames[tonumber(bossIndex)]
+    end
+
+    return nil
+end
+
 MilaUI.nameBlacklist = {
     ["the"] = true,
     ["of"] = true,


### PR DESCRIPTION
## Summary
- add `GetFrameForUnit` to Utility to centralize frame lookups
- update castbar and GUI utilities to use the helper
- loop through a unit list when updating all castbars
